### PR TITLE
add 'Login with Inventaire' option

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM mediawiki:1.35
 # extension install inspired from https://github.com/wmde/wikibase-docker/blob/master/wikibase/1.35/bundle/Dockerfile
 
 RUN apt-get update && \
-    apt-get install --yes --no-install-recommends jq=1.* curl=7.* && \
+    apt-get install --yes --no-install-recommends jq=1.* curl=7.* unzip && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /var/www/html/extensions
@@ -37,6 +37,15 @@ RUN bash download-extension.sh UniversalLanguageSelector
 RUN for archive_file in *.tar.gz; do tar xzf "$archive_file"; done && rm ./*.tar.gz
 
 RUN mkdir -p /tmp/mediawiki && chown -R www-data:www-data /tmp/mediawiki
+
+WORKDIR /root
+# Installing PHP Composer
+# See https://getcomposer.org/doc/faqs/how-to-install-composer-programmatically.md
+RUN curl -s https://raw.githubusercontent.com/composer/getcomposer.org/459bcaa/web/installer | php -- --quiet && ln -s /root/composer.phar /usr/bin/composer
+
+WORKDIR /var/www/html/extensions
+# Following installation steps from https://www.mediawiki.org/wiki/Extension:OAuth2_Client
+RUN git clone https://github.com/Schine/MW-OAuth2Client.git 2>&1 && cd MW-OAuth2Client && git submodule update --init 2>&1 && cd vendors/oauth2-client && composer install 2>&1
 
 WORKDIR /var/www/html
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update && \
 WORKDIR /var/www/html/extensions
 
 COPY download-extension.sh .
+COPY download-extension-OAuth2Client.sh .
 COPY wait-for-it.sh /wait-for-it.sh
 COPY entrypoint.sh /entrypoint.sh
 
@@ -36,16 +37,9 @@ RUN bash download-extension.sh UniversalLanguageSelector
 
 RUN for archive_file in *.tar.gz; do tar xzf "$archive_file"; done && rm ./*.tar.gz
 
+RUN bash download-extension-OAuth2Client.sh
+
 RUN mkdir -p /tmp/mediawiki && chown -R www-data:www-data /tmp/mediawiki
-
-WORKDIR /root
-# Installing PHP Composer
-# See https://getcomposer.org/doc/faqs/how-to-install-composer-programmatically.md
-RUN curl -s https://raw.githubusercontent.com/composer/getcomposer.org/459bcaa/web/installer | php -- --quiet && ln -s /root/composer.phar /usr/bin/composer
-
-WORKDIR /var/www/html/extensions
-# Following installation steps from https://www.mediawiki.org/wiki/Extension:OAuth2_Client
-RUN git clone https://github.com/Schine/MW-OAuth2Client.git 2>&1 && cd MW-OAuth2Client && git submodule update --init 2>&1 && cd vendors/oauth2-client && composer install 2>&1
 
 WORKDIR /var/www/html
 

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -150,6 +150,15 @@ $wgScribuntoDefaultEngine = 'luastandalone';
 
 $invHost = $_ENV['INV_HOST'];
 
+// Remove login links from all pages
+// https://www.mediawiki.org/wiki/Manual:Preventing_access#Removing_the_Login_link_from_all_pages
+function NoLoginLinkOnMainPage( &$personal_urls ){
+    unset( $personal_urls['login'] );
+    unset( $personal_urls['anonlogin'] );
+    return true;
+}
+$wgHooks['PersonalUrls'][]='NoLoginLinkOnMainPage';
+
 $wgOAuth2Client['client']['id']     = $_ENV['OAUTH_CLIENT_ID']; // The client ID assigned to you by the provider
 $wgOAuth2Client['client']['secret'] = $_ENV['OAUTH_CLIENT_SECRET']; // The client secret assigned to you by the provider
 

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -148,6 +148,28 @@ $wgPageLanguageUseDB = true; // manually changing page language
 
 $wgScribuntoDefaultEngine = 'luastandalone';
 
+$invHost = $_ENV['INV_HOST'];
+
+$wgOAuth2Client['client']['id']     = $_ENV['OAUTH_CLIENT_ID']; // The client ID assigned to you by the provider
+$wgOAuth2Client['client']['secret'] = $_ENV['OAUTH_CLIENT_SECRET']; // The client secret assigned to you by the provider
+
+$wgOAuth2Client['configuration']['authorize_endpoint']     = "$invHost/authorize";
+$wgOAuth2Client['configuration']['access_token_endpoint']  = "$invHost/api/oauth/token";
+$wgOAuth2Client['configuration']['api_endpoint']           = "$invHost/api/user";
+$wgOAuth2Client['configuration']['redirect_uri']           = "$wgServer/wiki/Special:OAuth2Client/callback";
+
+// Using the stableUsername as it will then be used as the user identifier by mediawiki
+// To change a user username, you would thus need to simultaneously rename the mediawiki user
+// (using the not yet installed https://www.mediawiki.org/wiki/Extension:Renameuser)
+// and update their 'stableUsername' in the Inventaire user database
+$wgOAuth2Client['configuration']['username'] = 'stableUsername'; // JSON path to stableUsername in the api_endpoint response
+$wgOAuth2Client['configuration']['email'] = 'email'; // JSON path to email in the api_endpoint response
+
+$wgOAuth2Client['configuration']['scopes'] = 'stable-username email';
+
+$wgOAuth2Client['configuration']['service_name'] = $wgSitename;
+$wgOAuth2Client['configuration']['service_login_link_text'] = "Login with Inventaire";
+
 wfLoadExtension( 'Babel' );
 wfLoadExtension( 'Cite' );
 wfLoadExtension( 'cldr' );
@@ -157,6 +179,7 @@ wfLoadExtension( 'DeleteBatch' );
 wfLoadExtension( 'ExternalData' );
 wfLoadExtension( 'LocalisationUpdate' );
 wfLoadExtension( 'MobileFrontend' );
+wfLoadExtension( 'MW-OAuth2Client' );
 wfLoadExtension( 'ParserFunctions' );
 wfLoadExtension( 'Scribunto' );
 wfLoadExtension( 'SendGrid' );

--- a/README.md
+++ b/README.md
@@ -5,9 +5,10 @@ Based on manual https://www.mediawiki.org/wiki/Docker/Hub but with repository ur
 ## Installation
 ### Quick start
  - Create a directory for images and set permissions to what will be the `www-data` user (`33`) inside the container: `mkdir ./images && sudo chown 33:33 ./images`
- - in `docker-compose.yml`, comment out `LocalSettings.php` volume line (so that `entrypoint.sh` knows it has to run the installation steps)
+ - /!\ Do not skip that step /!\ in `docker-compose.yml`, comment out `LocalSettings.php` volume line (so that `entrypoint.sh` knows it has to run the installation steps)
  - `cp dot_mw_env .mw_env && cp dot_db_env .db_env && chmod 600 .*env`
  - Start compose `docker-compose up`
+ - Once started corectly, you may re-comment `LocalSettings.php` volume line
 
 In case of database not found error, start the maintenance script update.php (for example with `docker exec -it container_name php /var/www/html/maintenance/update.php`)
 
@@ -22,6 +23,10 @@ more details at: https://www.mediawiki.org/wiki/Manual:Language#Page_content_lan
 ### Regarding translations administration
 
 One can see current status of translated pages through the special page `Special:PageTranslation`
+
+## Extensions
+
+Install new extensions by updating the Dockerfile, then `docker-compose up --build`.
 
 ## System Administration
 

--- a/dot_mw_env
+++ b/dot_mw_env
@@ -23,3 +23,7 @@ MYSQL_PASSWORD=wikidbuserpass
 
 # Sendgrid extension configuration
 WG_SENDGRD_API_KEY=yoursendgridapikey
+
+INV_HOST=https://inventaire.io
+OAUTH_CLIENT_ID=some_client_id_delivered_by_inventaire_server_admins
+OAUTH_CLIENT_SECRECT=the_associated_secret_also_delivered_by_inventaire_server_admins

--- a/download-extension-OAuth2Client.sh
+++ b/download-extension-OAuth2Client.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env sh
+
+cd /root
+
+# Installing PHP Composer
+# See https://getcomposer.org/doc/faqs/how-to-install-composer-programmatically.md
+curl -s https://raw.githubusercontent.com/composer/getcomposer.org/459bcaa/web/installer | php -- --quiet && ln -s /root/composer.phar /usr/bin/composer
+
+cd /var/www/html/extensions
+
+# Following installation steps from https://www.mediawiki.org/wiki/Extension:OAuth2_Client
+git clone https://github.com/Schine/MW-OAuth2Client.git 2>&1 && cd MW-OAuth2Client && git submodule update --init 2>&1 && cd vendors/oauth2-client && composer install 2>&1


### PR DESCRIPTION
using Extension:OAuth2_Client

addressing #2 

associated PRs
- https://github.com/inventaire/inventaire/pull/487
- https://github.com/inventaire/inventaire-client/pull/261

Remaining to do (possibly after merge):
- hide the normal login button (with css?)
- hide account preferences that don't apply to accounts managed this way
- reduce chances to end up on /wiki/Special:UserLogin and/or display a message to reduce confusion
