### PR TITLE
add Extension:Interwiki

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ RUN bash download-extension.sh DeleteBatch
 # Set version=master to get >= 2.2 to be able to use mw.ext.externalData,
 # see https://www.mediawiki.org/wiki/Extension:External_Data#Scribunto/Lua
 RUN bash download-extension.sh ExternalData master
+RUN bash download-extension.sh Interwiki
 RUN bash download-extension.sh LocalisationUpdate
 RUN bash download-extension.sh MobileFrontend
 RUN bash download-extension.sh ParserFunctions

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -179,6 +179,8 @@ $wgOAuth2Client['configuration']['scopes'] = 'stable-username email';
 $wgOAuth2Client['configuration']['service_name'] = $wgSitename;
 $wgOAuth2Client['configuration']['service_login_link_text'] = "Login with Inventaire";
 
+$wgGroupPermissions['sysop']['interwiki'] = true;
+
 wfLoadExtension( 'Babel' );
 wfLoadExtension( 'Cite' );
 wfLoadExtension( 'cldr' );
@@ -186,6 +188,7 @@ wfLoadExtension( 'CleanChanges' );
 wfLoadExtension( 'CodeEditor' );
 wfLoadExtension( 'DeleteBatch' );
 wfLoadExtension( 'ExternalData' );
+wfLoadExtension( 'Interwiki' );
 wfLoadExtension( 'LocalisationUpdate' );
 wfLoadExtension( 'MobileFrontend' );
 wfLoadExtension( 'MW-OAuth2Client' );


### PR DESCRIPTION
[Extension:Interwiki](https://www.mediawiki.org/wiki/Extension:Interwiki) would allow to easily edit the [interwikimap](https://wiki.inventaire.io/w/api.php?action=query&meta=siteinfo&siprop=interwikimap), which would come handy, for instance, to link to non-English editions of Wikipedia in translated articles (example: to link to [`frwiki:Fediverse`](https://fr.wikipedia.org/wiki/Fediverse))